### PR TITLE
enhance search to match filename or keyword metadata

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1285,7 +1285,14 @@ const PanelMenuButton = new Lang.Class({
             res = [];
             for (let i in applist) {
                 let app = applist[i];
-                if (app.get_name().toLowerCase().indexOf(pattern)!=-1 || (app.get_description() && app.get_description().toLowerCase().indexOf(pattern)!=-1))
+                let info = Gio.DesktopAppInfo.new (app.get_id());
+                if (
+                    app.get_name().toLowerCase().indexOf(pattern)!=-1
+                    || (app.get_description() && app.get_description().toLowerCase().indexOf(pattern)!=-1)
+                    || (info && info.get_display_name() && info.get_display_name().toLowerCase().indexOf(pattern)!=-1)
+                    || (info && info.get_executable() && info.get_executable().toLowerCase().indexOf(pattern)!=-1)
+                    || (info && info.get_keywords() && info.get_keywords().toString().toLowerCase().indexOf(pattern)!=-1)
+                )
                     res.push(app);
             }
         } else {


### PR DESCRIPTION
Some programs like "nautilus" don't contain the executable name
in either the application name or in the description.  Someone who
commonly starts a program from the commandline should be able
to find it from the search.

Finding a program based on the keywords can be very helpful
for new users who know what kind of program they run but don't
know the oddball name that it has.  This allows better
searching than just the description, and allows flexibility
for things like control panel to have many keywords added.
